### PR TITLE
fix: Workaround "No such file or directory" error

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ runs:
   using: composite
   steps:
     - shell: bash
-      run: ./update.sh
+      run: ${{ github.action_path }}/update.sh
       id: main


### PR DESCRIPTION
Running this in its current state yields the following error:

```
/home/runner/work/_temp/25bc5c35-052a-4916-9d6e-e5bd3df162b1.sh: line 1: ./update.sh: No such file or directory
```