### PR TITLE
feat: error when repo does not contain axe-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A GitHub action for updating [`axe-core`](https://github.com/dequelabs/axe-core) to the latest stable version.
 
+This action will fail if the repository contains no axe-core dependencies.
+If you do not wish for your job to exit due to this action's failure, use
+[continue-on-error](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) 
+to modify the step running this action.
+
 ## Example
 
 ```yaml

--- a/update.sh
+++ b/update.sh
@@ -41,6 +41,11 @@ for Package in $Packages; do
   cd - || exit 1
 done
 
+if [ -z "$PreviousVersion" ]; then
+  echo "This repo does not contain any axe-core dependencies. Exiting."
+  exit 1
+fi
+
 echo "version=$Version" >>"$GITHUB_OUTPUT"
 
 CleanVersion=$(echo "$PreviousVersion" | tr -cd '[:alnum:]._-')

--- a/update.sh
+++ b/update.sh
@@ -41,11 +41,6 @@ for Package in $Packages; do
   cd - || exit 1
 done
 
-if [ -z "$PreviousVersion" ]; then
-  echo "This repo does not contain any axe-core dependencies. Exiting."
-  exit 1
-fi
-
 echo "version=$Version" >>"$GITHUB_OUTPUT"
 
 CleanVersion=$(echo "$PreviousVersion" | tr -cd '[:alnum:]._-')
@@ -96,3 +91,9 @@ else
     echo "patch_version_updated=false"
   } >>"$GITHUB_OUTPUT"
 fi
+
+if [ -z "$PreviousVersion" ]; then
+  echo "This repo does not contain any axe-core dependencies. Exiting."
+  exit 1
+fi
+


### PR DESCRIPTION
This is meant to increase visibility for workflows that silently fail otherwise when using this to update axe-core.

I added a note to the README so that reusable actions that use this as a step can continue even if this fails.
When `continue-on-error` is used this should behave exactly as if this commit was not introduced.

Run with no axe-core dep: https://github.com/AdnoC/action-test/actions/runs/6123491178/job/16621484127
Tree: https://github.com/AdnoC/action-test/tree/update-axe-fail

Run with no axe-core dep, but continue-on-failure: https://github.com/AdnoC/action-test/actions/runs/6123541520/job/16621643185
Tree: https://github.com/AdnoC/action-test/tree/update-axe-fail-continue

Run with axe-core dep: https://github.com/AdnoC/action-test/actions/runs/6123561738/job/16621710831?pr=9
Tree: https://github.com/AdnoC/action-test/tree/update-axe-core-succeed